### PR TITLE
Adding basic TokenProviders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -301,6 +301,7 @@ __pycache__/
 # Python Auxiliary Tools
 *.egg-info/
 .tox/
+.mypy_cache/
 
 # Cake - Uncomment if you are using it
 # tools/**

--- a/msal_extensions/__init__.py
+++ b/msal_extensions/__init__.py
@@ -1,4 +1,5 @@
 """Provides auxiliary functionality to the `msal` package."""
 __version__ = "0.0.1"
 
-from .token_provider import TokenProvider, TokenProviderChain, ServicePrincipalProvider, DEFAULT_TOKEN_CHAIN
+from .token_provider import TokenProvider, TokenProviderChain, ServicePrincipalProvider, \
+    DEFAULT_TOKEN_CHAIN

--- a/msal_extensions/__init__.py
+++ b/msal_extensions/__init__.py
@@ -1,2 +1,4 @@
 """Provides auxiliary functionality to the `msal` package."""
 __version__ = "0.0.1"
+
+from .token_provider import TokenProvider, TokenProviderChain, ServicePrincipalProvider, DEFAULT_TOKEN_CHAIN

--- a/msal_extensions/token_provider.py
+++ b/msal_extensions/token_provider.py
@@ -1,10 +1,15 @@
+"""Provides mechanisms for easily acquiring tokens."""
 import os
-import abc
+from abc import ABCMeta, abstractmethod
 from msal.application import ConfidentialClientApplication
 
 
-class TokenProvider(abc.ABC):
-    @abc.abstractmethod
+class TokenProvider:  # pylint: disable=no-init
+    """Provides a logical contract for the most common needs associated with fetching a token."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
     def available(self):
         # type: () -> bool
         """
@@ -14,53 +19,72 @@ class TokenProvider(abc.ABC):
 
         # Implementer's Note (from @marstr and @devigned):
         #
-        # Q: Why doesn't this method take scopes? Wouldn't it be useful to know if a provider not only was available,
-        # but would ultimately be successful in finding an access token?
-        # A: This method seeks only to determine whether or not it is worth the latency of seeing whether or not a token
-        # request should be submitted. For example, consider Managed Service Identity (MSI), which allows applications
-        # to make an HTTPS call to get an access token. Quickly answering the question "Am I running in an environment
-        # that even has the capability to provide an MSI endpoint?" is likely easier than calling the MSI endpoint and
-        # and dealing with the latency associated with a failed network call. Combined with the fact that it is trivial
-        # to disregard "None" entries in a list, and it feels clear to the original authors that all potentially latent
-        # calls should happen in "get_token" to keep "available" as fast as possible.
+        # Q: Why doesn't this method take scopes? Wouldn't it be useful to know if a provider not
+        # only was available, but would ultimately be successful in finding an access token?
+        #
+        # A: This method seeks only to determine whether or not it is worth the latency of seeing
+        # whether or not a token request should be submitted. For example, consider Managed Service
+        # Identity (MSI), which allows applications to make an HTTPS call to get an access token.
+        # Quickly answering the question "Am I running in an environment that even has the
+        # capability to provide an MSI endpoint?" is likely easier than calling the MSI endpoint and
+        # dealing with the latency associated with a failed network call. Combined with the fact
+        # that it is trivial to disregard "None" entries in a list, and it feels clear to the
+        # original authors that all potentially latent calls should happen in "get_token" to keep
+        # "available" as fast as possible.
         raise NotImplementedError()
 
-    @abc.abstractmethod
-    def get_token(self, scopes=None, username=None):
+    @abstractmethod
+    def get_token(self, scopes=None):
         # type: (*str) -> {str:str}
         """
         Fetches an Access Token for a user needing a particular set of scopes.
-        :param scopes: The resource access or capabilities that the entity which will be using the token is requesting.
+        :param scopes: The resource access or capabilities that the entity which will be using the
+            token is requesting.
         :param username: The account name for the token that is being requested.
-        :return: An Access Token.
+        :return: A token ready to be decorated onto a web-request.
         """
         raise NotImplementedError()
 
 
 class TokenProviderChain(TokenProvider):
-    def __init__(self, *args):
+    """Aggregates many TokenProviders into a single priority queue of places to look to acquire
+    tokens.
+
+    Note: For performance reasons, it is wise to put the most TokenProviders that add the most
+    latency at the end of the chain.
+    """
+
+    def __init__(self, *args):  # pylint: disable=super-init-not-called
         self._links = list(args)
 
     def append(self, provider):
+        # type: (TokenProvider) -> None
+        """Add a link to the end of the chain.
+        :param provider the additional TokenProvider to call."""
         self._links.append(provider)
 
     def available(self):
-        """
-        Searches to see if any of the token providers
-        :return: True
+        # type: () -> bool
+        """Searches to see if any of the token providers registered with this chain are "available".
+        :return: True if any of the members of this chain declare themselves as available.
         """
         return any((item for item in self._links if item.available()))
 
-    def get_token(self, scopes=None, username=None):
+    def get_token(self, scopes=None):
+        # type: (list[str]) -> {str:str}
+        """U"""
         available = (item.get_token(scopes=scopes) for item in self._links if item.available())
         return next((token for token in available if token))
 
 
 class ServicePrincipalProvider(TokenProvider):
+    """Uses Service Principal credentials to acquire access tokens."""
     DEFAULT_CLIENT_ID = os.getenv('AZURE_CLIENT_ID')
     DEFAULT_CLIENT_SECRET = os.getenv('AZURE_CLIENT_SECRET')
 
-    def __init__(self, client_id=None, client_credential=None):
+    def __init__(self,  # pylint: disable=super-init-not-called
+                 client_id=None,
+                 client_credential=None):
         client_id = client_id or ServicePrincipalProvider.DEFAULT_CLIENT_ID
         client_credential = client_credential or ServicePrincipalProvider.DEFAULT_CLIENT_SECRET
 
@@ -70,10 +94,17 @@ class ServicePrincipalProvider(TokenProvider):
         )
 
     def available(self):
-        """ Always returns true, because if it was able to be instantiated, it is available for use."""
-        return True
+        """Indicates whether or not this instance was created with credentials or not.
+        :return True if both client_id and client_credential have values.
+        """
+        return self._app.client_id and self._app.client_credential
 
     def get_token(self, scopes=None):
+        """Acquires a token using a ConfidentialClient.
+        :param scopes: The resource access or capabilities that the entity which will be using the
+            token is requesting.
+        :return A token ready to be decorated onto a web-request.
+        """
         return self._app.acquire_token_for_client(scopes=scopes)
 
 

--- a/msal_extensions/token_provider.py
+++ b/msal_extensions/token_provider.py
@@ -53,20 +53,20 @@ class TokenProviderChain(TokenProvider):
 
     def get_token(self, scopes=None, username=None):
         available = (item.get_token(scopes=scopes) for item in self._links if item.available())
-        return next((for token in available if token))
+        return next((token for token in available if token))
 
 
 class ServicePrincipalProvider(TokenProvider):
     DEFAULT_CLIENT_ID = os.getenv('AZURE_CLIENT_ID')
     DEFAULT_CLIENT_SECRET = os.getenv('AZURE_CLIENT_SECRET')
 
-    def __init__(self, client_id=None, client_secret=None):
+    def __init__(self, client_id=None, client_credential=None):
         client_id = client_id or ServicePrincipalProvider.DEFAULT_CLIENT_ID
-        client_secret = client_secret or ServicePrincipalProvider.DEFAULT_CLIENT_SECRET
+        client_credential = client_credential or ServicePrincipalProvider.DEFAULT_CLIENT_SECRET
 
         self._app = ConfidentialClientApplication(
             client_id=client_id,
-            client_secret=client_secret,
+            client_credential=client_credential,
         )
 
     def available(self):

--- a/msal_extensions/token_provider.py
+++ b/msal_extensions/token_provider.py
@@ -1,0 +1,83 @@
+import os
+import abc
+from msal.application import ConfidentialClientApplication
+
+
+class TokenProvider(abc.ABC):
+    @abc.abstractmethod
+    def available(self):
+        # type: () -> bool
+        """
+        Communicates whether or not this TokenProvider will ever be able to return a token.
+        :return: True if this TokenProvider is enabled, False otherwise.
+        """
+
+        # Implementer's Note (from @marstr and @devigned):
+        #
+        # Q: Why doesn't this method take scopes? Wouldn't it be useful to know if a provider not only was available,
+        # but would ultimately be successful in finding an access token?
+        # A: This method seeks only to determine whether or not it is worth the latency of seeing whether or not a token
+        # request should be submitted. For example, consider Managed Service Identity (MSI), which allows applications
+        # to make an HTTPS call to get an access token. Quickly answering the question "Am I running in an environment
+        # that even has the capability to provide an MSI endpoint?" is likely easier than calling the MSI endpoint and
+        # and dealing with the latency associated with a failed network call. Combined with the fact that it is trivial
+        # to disregard "None" entries in a list, and it feels clear to the original authors that all potentially latent
+        # calls should happen in "get_token" to keep "available" as fast as possible.
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_token(self, scopes=None, username=None):
+        # type: (*str) -> {str:str}
+        """
+        Fetches an Access Token for a user needing a particular set of scopes.
+        :param scopes: The resource access or capabilities that the entity which will be using the token is requesting.
+        :param username: The account name for the token that is being requested.
+        :return: An Access Token.
+        """
+        raise NotImplementedError()
+
+
+class TokenProviderChain(TokenProvider):
+    def __init__(self, *args):
+        self._links = list(args)
+
+    def append(self, provider):
+        self._links.append(provider)
+
+    def available(self):
+        """
+        Searches to see if any of the token providers
+        :return: True
+        """
+        return any((item for item in self._links if item.available()))
+
+    def get_token(self, scopes=None, username=None):
+        available = (item.get_token(scopes=scopes) for item in self._links if item.available())
+        return next((for token in available if token))
+
+
+class ServicePrincipalProvider(TokenProvider):
+    DEFAULT_CLIENT_ID = os.getenv('AZURE_CLIENT_ID')
+    DEFAULT_CLIENT_SECRET = os.getenv('AZURE_CLIENT_SECRET')
+
+    def __init__(self, client_id=None, client_secret=None):
+        client_id = client_id or ServicePrincipalProvider.DEFAULT_CLIENT_ID
+        client_secret = client_secret or ServicePrincipalProvider.DEFAULT_CLIENT_SECRET
+
+        self._app = ConfidentialClientApplication(
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+    def available(self):
+        """ Always returns true, because if it was able to be instantiated, it is available for use."""
+        return True
+
+    def get_token(self, scopes=None):
+        return self._app.acquire_token_for_client(scopes=scopes)
+
+
+DEFAULT_TOKEN_CHAIN = TokenProviderChain()
+
+if ServicePrincipalProvider.DEFAULT_CLIENT_ID and ServicePrincipalProvider.DEFAULT_CLIENT_SECRET:
+    DEFAULT_TOKEN_CHAIN.append(ServicePrincipalProvider())

--- a/tests/test_token_provider.py
+++ b/tests/test_token_provider.py
@@ -1,0 +1,88 @@
+from msal_extensions import TokenProvider, TokenProviderChain
+
+
+class NeverAvailableTokenProvider(TokenProvider):
+    def __init__(self):
+        self._available_call_count = 0
+        self._get_token_call_count = 0
+
+    @property
+    def available_call_count(self):
+        return self._available_call_count
+
+    @property
+    def get_token_call_count(self):
+        return self._get_token_call_count
+
+    def available(self):
+        self._available_call_count += 1
+        return False
+
+    def get_token(self, scopes=None):
+        self._get_token_call_count += 1
+        return None
+
+
+class AlwaysAvailableTokenProvider(TokenProvider):
+    def __init__(self):
+        self._available_call_count = 0
+        self._get_token_call_count = 0
+
+    @property
+    def available_call_count(self):
+        return self._available_call_count
+
+    @property
+    def get_token_call_count(self):
+        return self._get_token_call_count
+
+    def available(self):
+        self._available_call_count += 1
+        return True
+
+    def get_token(self, scopes=None):
+        self._get_token_call_count += 1
+        return {
+            'access_token': 'faux_credentials',
+            'expires_in': 0}
+
+
+def test_chain_no_token_call_if_unavailable():
+    first = NeverAvailableTokenProvider()
+    second = NeverAvailableTokenProvider()
+
+    subject = TokenProviderChain(first, second)
+
+    assert first.available_call_count == 0
+    assert second.available_call_count == 0
+    assert first.get_token_call_count == 0
+    assert second.get_token_call_count == 0
+
+    assert not subject.available()
+
+    assert first.available_call_count == 1
+    assert second.available_call_count == 1
+    assert first.get_token_call_count == 0
+    assert second.get_token_call_count == 0
+
+    third = AlwaysAvailableTokenProvider()
+    subject = TokenProviderChain(first, second, third)
+    assert third.available_call_count == 0
+    assert third.get_token_call_count == 0
+
+    assert subject.available()
+
+    assert first.available_call_count == 2
+    assert second.available_call_count == 2
+    assert third.available_call_count == 1
+    assert first.get_token_call_count == 0
+    assert second.get_token_call_count == 0
+
+    assert subject.get_token(scopes=None)
+    assert first.available_call_count == 3
+    assert second.available_call_count == 3
+    assert third.available_call_count == 2
+    assert first.get_token_call_count == 0
+    assert second.get_token_call_count == 0
+    assert third.get_token_call_count == 1
+


### PR DESCRIPTION
* Define abstract class TokenProvider to define a contract for
implementations.
* Create ServicePrincipalProvider which uses well-known environment
variables should they be set.
* Create a "ProviderChain" which will allow a cascading search for
TokenProviders that can fulfill a request.

Closes #7 
Closes #8