### PR TITLE
Mark msal 0.5.x as compatible with the extension.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'Development Status :: 2 - Pre-Alpha',
     ],
     install_requires=[
-        'msal~=0.4.1',
+        'msal>=0.4.1,<0.6.0',
         'portalocker~=1.0',
     ],
     tests_require=['pytest'],


### PR DESCRIPTION
In preparation for releasing 0.1.1, we want to make sure that our constraints are set correctly.