### PR TITLE
MSAL Python Extensions 0.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
       env: TOXENV=py37
       os: linux
       dist: xenial
+    - python: "3.8"
+      env: TOXENV=py38
+      os: linux
+      dist: xenial
     - name: "Python 3.7 on macOS"
       env: TOXENV=py37
       os: osx

--- a/msal_extensions/__init__.py
+++ b/msal_extensions/__init__.py
@@ -1,5 +1,5 @@
 """Provides auxiliary functionality to the `msal` package."""
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'Development Status :: 2 - Pre-Alpha',
     ],
     install_requires=[
-        'msal>=0.4.1,<0.6.0',
+        'msal>=0.4.1,<1.0.0',
         'portalocker~=1.0',
     ],
     tests_require=['pytest'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37
+envlist = py27,py35,py36,py37,py38
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
This release provides:

* same functionality as the previous version
* the test cases are now also run on Python 3.8
* can work with MSAL Python 0.6.0 or higher, until next MSAL Python major version bump