### PR TITLE
Release 0.2.1

### DIFF
--- a/msal_extensions/__init__.py
+++ b/msal_extensions/__init__.py
@@ -1,5 +1,5 @@
 """Provides auxiliary functionality to the `msal` package."""
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 import sys
 

--- a/msal_extensions/cache_lock.py
+++ b/msal_extensions/cache_lock.py
@@ -12,17 +12,23 @@ class CrossPlatLock(object):
     """
     def __init__(self, lockfile_path):
         self._lockpath = lockfile_path
-        self._fh = None
+        self._lock = portalocker.Lock(
+            lockfile_path,
+            mode='wb+',
+            # In posix systems, we HAVE to use LOCK_EX(exclusive lock) bitwise ORed
+            # with LOCK_NB(non-blocking) to avoid blocking on lock acquisition.
+            # More information here:
+            # https://docs.python.org/3/library/fcntl.html#fcntl.lockf
+            flags=portalocker.LOCK_EX | portalocker.LOCK_NB,
+            buffering=0)
 
     def __enter__(self):
-        pid = os.getpid()
-
-        self._fh = open(self._lockpath, 'wb+', buffering=0)
-        portalocker.lock(self._fh, portalocker.LOCK_EX)
-        self._fh.write('{} {}'.format(pid, sys.argv[0]).encode('utf-8'))
+        file_handle = self._lock.__enter__()
+        file_handle.write('{} {}'.format(os.getpid(), sys.argv[0]).encode('utf-8'))
+        return file_handle
 
     def __exit__(self, *args):
-        self._fh.close()
+        self._lock.__exit__(*args)
         try:
             # Attempt to delete the lockfile. In either of the failure cases enumerated below, it is
             # likely that another process has raced this one and ended up clearing or locking the

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     package_data={'': ['LICENSE']},
     install_requires=[
         'msal>=0.4.1,<2.0.0',
-        'portalocker~=1.0',
+        'portalocker~=1.6',
     ],
     tests_require=['pytest'],
 )

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,17 @@ __version__ = re.search(
     io.open('msal_extensions/__init__.py', encoding='utf_8_sig').read()
     ).group(1)
 
+try:
+    long_description = open('README.md').read()
+except OSError:
+    long_description = "README.md is not accessible on TRAVIS CI's Python 3.5"
+
 setup(
     name='msal-extensions',
     version=__version__,
     packages=find_packages(),
-    long_description=open('README.md').read(),
-    long_description_content_type="text/markdown",    
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
     ],

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ setup(
     name='msal-extensions',
     version=__version__,
     packages=find_packages(),
+    long_description=open('README.md').read(),
+    long_description_content_type="text/markdown",    
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
     ],


### PR DESCRIPTION
* Functionally the same as 0.2.0, but we change the installation-time and import-time dependency of `PyGObject` to run-time dependency. This would make the installation easier for those customers who do not necessarily need to use the Encryption on Linux. (#47)
* The version 1.6.0+ of upstream package `portalocker` is only required on Windows. Other platforms remain with portalocker 1.0.0+. (#49)