### PR TITLE
Use more precise dependency declaration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
     package_data={'': ['LICENSE']},
     install_requires=[
         'msal>=0.4.1,<2.0.0',
-        'portalocker~=1.6',
+        "portalocker~=1.6;platform_system=='Windows'",
+        "portalocker~=1.0;platform_system!='Windows'",
         "pathlib2;python_version<'3.0'",
         ## We choose to NOT define a hard dependency on this.
         # "pygobject>=3,<4;platform_system=='Linux'",


### PR DESCRIPTION
Per [a discussion](https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/43#issuecomment-617739430) and its subsequent off-line discussion with @bluca , we realize that package maintainers on Linux might not want to aggressively upgrade a dependency to its latest version. So, in this PR, we make it clear that the portalocker 1.6.0 dependency requirement is only needed on Windows.