### PR TITLE
Handle file not found exceptions on Python 2.7

### DIFF
--- a/msal_extensions/token_cache.py
+++ b/msal_extensions/token_cache.py
@@ -35,7 +35,7 @@ class PersistedTokenCache(msal.SerializableTokenCache):
             if self._last_sync < self._persistence.time_last_modified():
                 self.deserialize(self._persistence.load())
                 self._last_sync = time.time()
-        except IOError as exp:
+        except EnvironmentError as exp:
             if exp.errno != errno.ENOENT:
                 raise
             # Otherwise, from cache's perspective, a nonexistent file is a NO-OP

--- a/tests/test_agnostic_backend.py
+++ b/tests/test_agnostic_backend.py
@@ -44,3 +44,8 @@ def test_current_platform_cache_roundtrip_with_alias_class(temp_location):
 def test_persisted_token_cache(temp_location):
     _test_token_cache_roundtrip(PersistedTokenCache(FilePersistence(temp_location)))
 
+def test_file_not_found_error_is_not_raised():
+    persistence = FilePersistence('non_existing_file')
+    cache = PersistedTokenCache(persistence=persistence)
+    # An exception raised here will fail the test case as it is supposed to be a NO-OP
+    cache.find('')


### PR DESCRIPTION
On Python 3, calling `PersistedTokenCache.find()` on a nonexistent cache file is a no-op, so this code works:
```py
from msal_extensions import FilePersistence, PersistedTokenCache

persistence = FilePersistence('nope')
cache = PersistedTokenCache(persistence=persistence)
cache.find('')
```
On Python 2.7 it raises a platform-specific error: `WindowsError` on Windows, `OSError` on Linux (I haven't tried it on macOS). The difference in behavior is due to `PersistedTokenCache` anticipating `IOError` when a file isn't found. Neither `WindowsError` nor `OSError` is a subclass of `IOError`. All these errors are subclasses of `EnvironmentError` though, and that class has the `errno` attribute, so a simple fix is to handle `EnvironmentError` here.