### PR TITLE
Call `_reload_if_necessary` in `PersistedTokenCache.__init__`

### DIFF
--- a/msal_extensions/token_cache.py
+++ b/msal_extensions/token_cache.py
@@ -26,6 +26,7 @@ class PersistedTokenCache(msal.SerializableTokenCache):
         self._persistence = persistence
         self._last_sync = 0  # _last_sync is a Unixtime
         self.is_encrypted = persistence.is_encrypted
+        self._reload_if_necessary()
 
     def _reload_if_necessary(self):
         # type: () -> None


### PR DESCRIPTION
Currently `_reload_if_necessary` is only lazily called when `modify` or `find` is called.

However, if `modify` or `find` is not called, `SerializableTokenCache.serialize` won't work as expected because `self._cache` is `{}`. The caller must workaround it by either 

1. call `modify` or `find` once
2. manually call the protected method `_reload_if_necessary` 