### PR TITLE
Raise without log polluting the console

### DIFF
--- a/msal_extensions/libsecret.py
+++ b/msal_extensions/libsecret.py
@@ -13,33 +13,29 @@ Alternatively, you could skip Cairo & PyCairo, but you still need to do all thes
     pip install wheel
     PYGOBJECT_WITHOUT_PYCAIRO=1 pip install --no-build-isolation pygobject
 """
-import logging
-
-logger = logging.getLogger(__name__)
 
 try:
     import gi  # https://github.com/AzureAD/microsoft-authentication-extensions-for-python/wiki/Encryption-on-Linux  # pylint: disable=line-too-long
 except ImportError:
-    logger.exception(
-        """Runtime dependency of PyGObject is missing.
+    raise ImportError("""Unable to import module 'gi'
+Runtime dependency of PyGObject is missing.
 Depends on your Linux distro, you could install it system-wide by something like:
     sudo apt install python3-gi python3-gi-cairo gir1.2-secret-1
 If necessary, please refer to PyGObject's doc:
 https://pygobject.readthedocs.io/en/latest/getting_started.html
-""")
-    raise
+""")  # Message via exception rather than log
 
 try:
     # pylint: disable=no-name-in-module
     gi.require_version("Secret", "1")  # Would require a package gir1.2-secret-1
     # pylint: disable=wrong-import-position
     from gi.repository import Secret  # Would require a package gir1.2-secret-1
-except (ValueError, ImportError):
-    logger.exception(
+except (ValueError, ImportError) as ex:
+    raise type(ex)(
         """Require a package "gir1.2-secret-1" which could be installed by:
         sudo apt install gir1.2-secret-1
-        """)
-    raise
+        """)  # Message via exception rather than log
+
 
 class LibSecretAgent(object):
     """A loader/saver built on top of low-level libsecret"""
@@ -134,7 +130,5 @@ def trial_run():
   you may need to install gnome-keyring package.
 * Headless mode (such as in an ssh session) is not supported.
 """
-        logger.exception(message)  # This log contains trace stack for debugging
-        logger.warning(message)  # This is visible by default
-        raise
+        raise RuntimeError(message)  # Message via exception rather than log
 


### PR DESCRIPTION
This may fix #92 .

@chlowell , continuing our conversation in #92, this PR currently chooses to not use `six` (which is never in MSAL or MSAL EX dependency, by the way).