### PR TITLE
Allow portalocker 2 on Python 3.5+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,17 @@ setup(
     package_data={'': ['LICENSE']},
     install_requires=[
         'msal>=0.4.1,<2.0.0',
-        "portalocker~=1.6;platform_system=='Windows'",
-        "portalocker~=1.0;platform_system!='Windows'",
+
+        # In order to implement these requirements:
+        #       Lowerbound = (1.6 if playform_system == 'Windows' else 1.0)
+        #       Upperbound < (3 if python_version >= '3.5' else 2)
+        # The following 4 lines use the `and` syntax defined here:
+        #       https://www.python.org/dev/peps/pep-0508/#grammar
+        "portalocker<3,>=1.0;python_version>='3.5' and platform_system!='Windows'",
+        "portalocker<2,>=1.0;python_version=='2.7' and platform_system!='Windows'",
+        "portalocker<3,>=1.6;python_version>='3.5' and platform_system=='Windows'",
+        "portalocker<2,>=1.6;python_version=='2.7' and platform_system=='Windows'",
+
         "pathlib2;python_version<'3.0'",
         ## We choose to NOT define a hard dependency on this.
         # "pygobject>=3,<4;platform_system=='Linux'",


### PR DESCRIPTION
Thanks @dhirschfeld for bringing #94 to our attention. It turns out, our attempt in #95 was not quite there yet, so my offline trial-and-error led me to this PR. It should work, and it will close #94 and close #95.

P.S.: After merging this PR, the change will not immediately go live, but it will be included in our next release.