### PR TITLE
Making all platform-dependent parameters optional

### DIFF
--- a/sample/persistence_sample.py
+++ b/sample/persistence_sample.py
@@ -10,7 +10,7 @@ def build_persistence(location, fallback_to_plaintext=False):
     if sys.platform.startswith('win'):
         return FilePersistenceWithDataProtection(location)
     if sys.platform.startswith('darwin'):
-        return KeychainPersistence(location, "my_service_name", "my_account_name")
+        return KeychainPersistence(location)
     if sys.platform.startswith('linux'):
         try:
             return LibsecretPersistence(
@@ -21,8 +21,6 @@ def build_persistence(location, fallback_to_plaintext=False):
                 # unless there would frequently be a desktop session and
                 # a remote ssh session being active simultaneously.
                 location,
-                schema_name="my_schema_name",
-                attributes={"my_attr1": "foo", "my_attr2": "bar"},
                 )
         except:  # pylint: disable=bare-except
             if not fallback_to_plaintext:
@@ -31,6 +29,7 @@ def build_persistence(location, fallback_to_plaintext=False):
     return FilePersistence(location)
 
 persistence = build_persistence("storage.bin", fallback_to_plaintext=False)
+print("Type of persistence: {}".format(persistence.__class__.__name__))
 print("Is this persistence encrypted?", persistence.is_encrypted)
 
 data = {  # It can be anything, here we demonstrate an arbitrary json object

--- a/sample/token_cache_sample.py
+++ b/sample/token_cache_sample.py
@@ -10,7 +10,7 @@ def build_persistence(location, fallback_to_plaintext=False):
     if sys.platform.startswith('win'):
         return FilePersistenceWithDataProtection(location)
     if sys.platform.startswith('darwin'):
-        return KeychainPersistence(location, "my_service_name", "my_account_name")
+        return KeychainPersistence(location)
     if sys.platform.startswith('linux'):
         try:
             return LibsecretPersistence(
@@ -21,8 +21,6 @@ def build_persistence(location, fallback_to_plaintext=False):
                 # unless there would frequently be a desktop session and
                 # a remote ssh session being active simultaneously.
                 location,
-                schema_name="my_schema_name",
-                attributes={"my_attr1": "foo", "my_attr2": "bar"},
                 )
         except:  # pylint: disable=bare-except
             if not fallback_to_plaintext:
@@ -31,6 +29,7 @@ def build_persistence(location, fallback_to_plaintext=False):
     return FilePersistence(location)
 
 persistence = build_persistence("token_cache.bin")
+print("Type of persistence: {}".format(persistence.__class__.__name__))
 print("Is this persistence encrypted?", persistence.is_encrypted)
 
 cache = PersistedTokenCache(persistence)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -54,8 +54,7 @@ def test_nonexistent_file_persistence_with_data_protection(temp_location):
     not sys.platform.startswith('darwin'),
     reason="Requires OSX. Whether running on TRAVIS CI does not seem to matter.")
 def test_keychain_persistence(temp_location):
-    _test_persistence_roundtrip(KeychainPersistence(
-        temp_location, "my_service_name", "my_account_name"))
+    _test_persistence_roundtrip(KeychainPersistence(temp_location))
 
 @pytest.mark.skipif(
     not sys.platform.startswith('darwin'),
@@ -69,11 +68,7 @@ def test_nonexistent_keychain_persistence(temp_location):
     is_running_on_travis_ci or not sys.platform.startswith('linux'),
     reason="Requires Linux Desktop. Headless or SSH session won't work.")
 def test_libsecret_persistence(temp_location):
-    _test_persistence_roundtrip(LibsecretPersistence(
-        temp_location,
-        "my_schema_name",
-        {"my_attr_1": "foo", "my_attr_2": "bar"},
-        ))
+    _test_persistence_roundtrip(LibsecretPersistence(temp_location))
 
 @pytest.mark.skipif(
     is_running_on_travis_ci or not sys.platform.startswith('linux'),


### PR DESCRIPTION
## Changes in this PR

Az CLI uses 2 instances of persistence for different data, stored in different files. @jiasli found it unobvious that he would need to use different `service_name` and `account_name` when running on mac. This PR attempts to hide/handle this detail, by automatically generate those 2 parameters based on the (signal) file location.

## Future ideas that are not (yet?) in this PR

1. Historically, before we introduced all those platform-dependent parameters, there was a unified `TokenCache` interface across all platforms.
2. Later when we added (more and more) platform-dependent parameters, we attempted to keep a similar cross-platform `build_persistence()` helper but it did not really hide all those platform-dependent details, it merely becomes a union of all parameters.
   ```python
   def build_persistence(
       ...,
        entropy='',  # For Windows
        service_name=None, account_name=None,  # For OSX
        schema_name="", attributes=None, fallback_to_plaintext=False,  # For Linux
        **kwargs):  # Extra parameters will be relayed to LibsecretPersistence
   ```
   Therefore, @chlowell [convinced us](https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/44#discussion_r407705595) to remove that helper, and rightfully so:
   > I feel the helper doesn't really help me because it doesn't hide the particulars of persistence. To use it, I must learn which options apply on which platforms, and how; which ones are truly optional. Then I either pass all options at once or call the helper conditionally by platform. I prefer to write the conditional code because it would be easier for future generations to understand. At that point I may as well just import and configure persistence classes directly, that's nicely explicit.

3. Now, if this PR would be welcomed and merged, the next step would be reconsidering the introduction of a unified helper. This time, it won't need any platform-dependent parameters. Perhaps even a unified Persistence alias:
   ```python
   # in __init__.py
   if sys.platform.startswith('win'):
       from .persistence import FilePersistenceWithDataProtection as EncryptedPesistence
   elif sys.platform.startswith('darwin'):
       from .persistence import KeyChainPersistnce as EncryptedPesistence
   else:
       from .persistence import LibsecretPersistence as EncryptedPesistence
   ```
   This way, the `EncryptedPersistence` would still be different classes with different signatures on different platforms, but at least their required parameters would be unified so that you could initialize one as `EncryptedPersistence('/path/to/my/file.bin')`. And that would help resolve `https://github.com/AzureAD/microsoft-authentication-extensions-for-python/issues/87`.

@chlowell , @jiasli, thoughts?

UPDATE at 12/7/2021: We decided to reject proposal 3, because that alias would end up with different shapes. We postpone proposal 2 to a future release, after we gain some real-world usage with this PR.