### PR TITLE
Provide catch-able exceptions for 2 dpapi errors

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -2,6 +2,7 @@
 good-names=
     logger
 disable=
+    consider-using-f-string,  # For Python < 3.6
     super-with-arguments,  # For Python 2.x
     raise-missing-from,  # For Python 2.x
     trailing-newlines,

--- a/msal_extensions/persistence.py
+++ b/msal_extensions/persistence.py
@@ -56,19 +56,31 @@ def _auto_hash(input_string):
 
 
 # We do not aim to wrap every os-specific exception.
-# Here we define only the most common one,
-# otherwise caller would need to catch os-specific persistence exceptions.
-class PersistenceNotFound(IOError):  # Use IOError rather than OSError as base,
+# Here we standardize only the most common ones,
+# otherwise caller would need to catch os-specific underlying exceptions.
+class PersistenceError(IOError):  # Use IOError rather than OSError as base,
+    """The base exception for persistence."""
         # because historically an IOError was bubbled up and expected.
         # https://github.com/AzureAD/microsoft-authentication-extensions-for-python/blob/0.2.2/msal_extensions/token_cache.py#L38
         # Now we want to maintain backward compatibility even when using Python 2.x
         # It makes no difference in Python 3.3+ where IOError is an alias of OSError.
+    def __init__(self, err_no=None, message=None, location=None):  # pylint: disable=useless-super-delegation
+        super(PersistenceError, self).__init__(err_no, message, location)
+
+
+class PersistenceNotFound(PersistenceError):
     """This happens when attempting BasePersistence.load() on a non-existent persistence instance"""
     def __init__(self, err_no=None, message=None, location=None):
         super(PersistenceNotFound, self).__init__(
-            err_no or errno.ENOENT,
-            message or "Persistence not found",
-            location)
+            err_no=errno.ENOENT,
+            message=message or "Persistence not found",
+            location=location)
+
+class PersistenceEncryptionError(PersistenceError):
+    """This could be raised by persistence.save()"""
+
+class PersistenceDecryptionError(PersistenceError):
+    """This could be raised by persistence.load()"""
 
 
 class BasePersistence(ABC):
@@ -177,7 +189,13 @@ class FilePersistenceWithDataProtection(FilePersistence):
 
     def save(self, content):
         # type: (str) -> None
-        data = self._dp_agent.protect(content)
+        try:
+            data = self._dp_agent.protect(content)
+        except OSError as exception:
+            raise PersistenceEncryptionError(
+                err_no=getattr(exception, "winerror", None),  # Exists in Python 3 on Windows
+                message="Encryption failed: {}. Consider disable encryption.".format(exception),
+                )
         with os.fdopen(_open(self._location), 'wb+') as handle:
             handle.write(data)
 
@@ -186,7 +204,6 @@ class FilePersistenceWithDataProtection(FilePersistence):
         try:
             with open(self._location, 'rb') as handle:
                 data = handle.read()
-            return self._dp_agent.unprotect(data)
         except EnvironmentError as exp:  # EnvironmentError in Py 2.7 works across platform
             if exp.errno == errno.ENOENT:
                 raise PersistenceNotFound(
@@ -199,6 +216,17 @@ class FilePersistenceWithDataProtection(FilePersistence):
                 "DPAPI error likely caused by file content not previously encrypted. "
                 "App developer should migrate by calling save(plaintext) first.")
             raise
+        try:
+            return self._dp_agent.unprotect(data)
+        except OSError as exception:
+            raise PersistenceDecryptionError(
+                err_no=getattr(exception, "winerror", None),  # Exists in Python 3 on Windows
+                message="Decryption failed: {}. "
+                    "App developer may consider this guidance: "
+                    "https://github.com/AzureAD/microsoft-authentication-extensions-for-python/wiki/PersistenceDecryptionError"  # pylint: disable=line-too-long
+                    .format(exception),
+                location=self._location,
+                )
 
 
 class KeychainPersistence(BasePersistence):

--- a/msal_extensions/windows.py
+++ b/msal_extensions/windows.py
@@ -39,6 +39,15 @@ class DataBlob(ctypes.Structure):  # pylint: disable=too-few-public-methods
         _MEMCPY(blob_buffer, pb_data, cb_data)
         return blob_buffer.raw
 
+_err_description = {
+    # Keys came from real world observation, values came from winerror.h (http://errors (Microsoft internal))
+    -2146893813: "Key not valid for use in specified state.",
+    -2146892987: "The requested operation cannot be completed. "
+        "The computer must be trusted for delegation and "
+        "the current user account must be configured to allow delegation. "
+        "See also https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/enable-computer-and-user-accounts-to-be-trusted-for-delegation",
+    13: "The data is invalid",
+    }
 
 # This code is modeled from a StackOverflow question, which can be found here:
 # https://stackoverflow.com/questions/463832/using-dpapi-with-python
@@ -82,7 +91,7 @@ class WindowsDataProtectionAgent(object):
                 _LOCAL_FREE(result.pbData)
 
         err_code = _GET_LAST_ERROR()
-        raise OSError(256, '', '', err_code)
+        raise OSError(None, _err_description.get(err_code), None, err_code)
 
     def unprotect(self, cipher_text):
         # type: (bytes) -> str
@@ -111,4 +120,4 @@ class WindowsDataProtectionAgent(object):
             finally:
                 _LOCAL_FREE(result.pbData)
         err_code = _GET_LAST_ERROR()
-        raise OSError(256, '', '', err_code)
+        raise OSError(None, _err_description.get(err_code), None, err_code)

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,7 @@ envlist = py27,py35,py36,py37,py38
 deps = pytest
 passenv =
     TRAVIS
+    GITHUB_ACTIONS
+
 commands =
     pytest


### PR DESCRIPTION
This PR provides user-friendly exception messages for real-world observation: https://github.com/Azure/azure-cli/issues/20231, https://github.com/Azure/azure-cli/issues/20759, and https://github.com/Azure/azure-cli/issues/21010 . The default error messages is not (and can not) be specific to Azure CLI, but Azure CLI can choose to catch the 2 new exceptions `PersistenceEncryptionError` and `PersistenceDecryptionError`, and then emit their own error messages.

CC: @jiasli