### PR TITLE
Refine error messages of `PersistenceEncryptionError` and `PersistenceDecryptionError`

### DIFF
--- a/msal_extensions/persistence.py
+++ b/msal_extensions/persistence.py
@@ -210,7 +210,7 @@ class FilePersistenceWithDataProtection(FilePersistence):
         except OSError as exception:
             raise PersistenceEncryptionError(
                 err_no=getattr(exception, "winerror", None),  # Exists in Python 3 on Windows
-                message="Encryption failed: {}. Consider disable encryption.".format(exception),
+                message="Encryption failed: {} Consider disable encryption.".format(exception),
                 )
         with os.fdopen(_open(self._location), 'wb+') as handle:
             handle.write(data)
@@ -237,7 +237,7 @@ class FilePersistenceWithDataProtection(FilePersistence):
         except OSError as exception:
             raise PersistenceDecryptionError(
                 err_no=getattr(exception, "winerror", None),  # Exists in Python 3 on Windows
-                message="Decryption failed: {}. "
+                message="Decryption failed: {} "
                     "App developer may consider this guidance: "
                     "https://github.com/AzureAD/microsoft-authentication-extensions-for-python/wiki/PersistenceDecryptionError"  # pylint: disable=line-too-long
                     .format(exception),
@@ -342,4 +342,3 @@ class LibsecretPersistence(BasePersistence):
 # with a FilePersistence to achieve
 #  https://github.com/AzureAD/microsoft-authentication-extensions-for-python/issues/12
 # But this idea is not pursued at this time.
-

--- a/msal_extensions/windows.py
+++ b/msal_extensions/windows.py
@@ -46,7 +46,7 @@ _err_description = {
         "The computer must be trusted for delegation and "
         "the current user account must be configured to allow delegation. "
         "See also https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/enable-computer-and-user-accounts-to-be-trusted-for-delegation",
-    13: "The data is invalid",
+    13: "The data is invalid.",
     }
 
 # This code is modeled from a StackOverflow question, which can be found here:
@@ -91,7 +91,7 @@ class WindowsDataProtectionAgent(object):
                 _LOCAL_FREE(result.pbData)
 
         err_code = _GET_LAST_ERROR()
-        raise OSError(None, _err_description.get(err_code), None, err_code)
+        raise OSError(None, _err_description.get(err_code, ''), None, err_code)
 
     def unprotect(self, cipher_text):
         # type: (bytes) -> str
@@ -120,4 +120,4 @@ class WindowsDataProtectionAgent(object):
             finally:
                 _LOCAL_FREE(result.pbData)
         err_code = _GET_LAST_ERROR()
-        raise OSError(None, _err_description.get(err_code), None, err_code)
+        raise OSError(None, _err_description.get(err_code, ''), None, err_code)


### PR DESCRIPTION
Since period is already in https://github.com/AzureAD/microsoft-authentication-extensions-for-python/blob/e30080b5c1b3e2c801bf371631c3c7afd4cda27a/msal_extensions/windows.py#L44

The error message becomes 

```
Decryption failed: [WinError -2146893813] Key not valid for use in specified state.. App developer may consider this guidance: https://github.com/AzureAD/microsoft-authentication-extensions-for-python/wiki/PersistenceDecryptionError: 'C:\\Users\\xxx\\.azure\\msal_token_cache.bin'
```