### PR TITLE
Update trove classifiers and build matrix for Python 3.10

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 2.7]
+        python-version: [3.7, 3.8, 3.9, "3.10", 2.7]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
@@ -26,6 +26,8 @@ jobs:
             toxenv: "py38"
           - python-version: 3.9
             toxenv: "py39"
+          - python-version: "3.10"
+            toxenv: "py310"
           - python-version: 2.7
             toxenv: "py27"
           - python-version: 3.9

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 2.7]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12, 2.7]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
@@ -28,6 +28,10 @@ jobs:
             toxenv: "py39"
           - python-version: "3.10"
             toxenv: "py310"
+          - python-version: 3.11
+            toxenv: "py311"
+          - python-version: 3.12
+            toxenv: "py312"
           - python-version: 2.7
             toxenv: "py27"
           - python-version: 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,17 @@
 universal=1
 
 [metadata]
-license = MIT
+license = MIT License
 project_urls =    Changelog = https://github.com/AzureAD/microsoft-authentication-extensions-for-python/releases
 classifiers =
     License :: OSI Approved :: MIT License
     Development Status :: 5 - Production/Stable
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+
 description = Microsoft Authentication Library extensions (MSAL EX) provides a persistence API that can save your data on disk, encrypted on Windows, macOS and Linux. Concurrent data access will be coordinated by a file lock mechanism.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38
+envlist = py27,py35,py36,py37,py38,py39,py310
 
 [testenv]
 deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,py310
+envlist = py27,py35,py36,py37,py38,py39,py310,py311,py312
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
This PR updates the trove classifiers to specify which versions are supported.

It also adds 3.10 to the build matrix.