### PR TITLE
Dropping Python 2.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 2.7]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
@@ -27,8 +27,6 @@ jobs:
             toxenv: "py38"
           - python-version: 3.9
             toxenv: "py39"
-          - python-version: 2.7
-            toxenv: "py27"
           - python-version: 3.9
             os: ubuntu-latest
             lint: "true"

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ persistence.save(json.dumps(data))
 assert json.loads(persistence.load()) == data
 ```
 
+## Python version support policy
+
+Python versions which are 6 months older than their
+[end-of-life cycle defined by Python Software Foundation (PSF)](https://devguide.python.org/versions/#versions)
+will not receive new feature updates from this library.
+
 
 ## Community Help and Support
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 
 [bdist_wheel]
-universal=1
+universal=0
 
 [metadata]
 license = MIT
@@ -9,4 +9,9 @@ project_urls =    Changelog = https://github.com/AzureAD/microsoft-authenticatio
 classifiers =
     License :: OSI Approved :: MIT License
     Development Status :: 5 - Production/Stable
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 description = Microsoft Authentication Library extensions (MSAL EX) provides a persistence API that can save your data on disk, encrypted on Windows, macOS and Linux. Concurrent data access will be coordinated by a file lock mechanism.

--- a/setup.py
+++ b/setup.py
@@ -20,20 +20,13 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     package_data={'': ['LICENSE']},
+    python_requires=">=3.7",
     install_requires=[
         'msal>=0.4.1,<2.0.0',
 
-        # In order to implement these requirements:
-        #       Lowerbound = (1.6 if playform_system == 'Windows' else 1.0)
-        #       Upperbound < (3 if python_version >= '3.5' else 2)
-        # The following 4 lines use the `and` syntax defined here:
-        #       https://www.python.org/dev/peps/pep-0508/#grammar
-        "portalocker<3,>=1.0;python_version>='3.5' and platform_system!='Windows'",
-        "portalocker<2,>=1.0;python_version=='2.7' and platform_system!='Windows'",
-        "portalocker<3,>=1.6;python_version>='3.5' and platform_system=='Windows'",
-        "portalocker<2,>=1.6;python_version=='2.7' and platform_system=='Windows'",
+        "portalocker<3,>=1.0;platform_system!='Windows'",
+        "portalocker<3,>=1.6;platform_system=='Windows'",
 
-        "pathlib2;python_version<'3.0'",
         ## We choose to NOT define a hard dependency on this.
         # "pygobject>=3,<4;platform_system=='Linux'",
 


### PR DESCRIPTION
The existing test automation were failing due to the infrastructure already dropped Python 2.7 support.