### PR TITLE
Set proper lower bound for `portalocker` dependency, drop `packaging` dependency

### DIFF
--- a/msal_extensions/cache_lock.py
+++ b/msal_extensions/cache_lock.py
@@ -6,7 +6,6 @@ import time
 import logging
 
 import portalocker
-from packaging.version import Version
 
 
 logger = logging.getLogger(__name__)
@@ -19,9 +18,6 @@ class CrossPlatLock(object):
     """
     def __init__(self, lockfile_path):
         self._lockpath = lockfile_path
-        # Support for passing through arguments to the open syscall was added in v1.4.0
-        open_kwargs = ({'buffering': 0}
-            if Version(portalocker.__version__) >= Version("1.4.0") else {})
         self._lock = portalocker.Lock(
             lockfile_path,
             mode='wb+',
@@ -30,7 +26,10 @@ class CrossPlatLock(object):
             # More information here:
             # https://docs.python.org/3/library/fcntl.html#fcntl.lockf
             flags=portalocker.LOCK_EX | portalocker.LOCK_NB,
-            **open_kwargs)
+            # Support for passing through arguments to the open syscall
+            # was added in Portalocker v1.4.0 (2019-02-11).
+            buffering=0,
+        )
 
     def _try_to_create_lock_file(self):
         timeout = 5

--- a/setup.py
+++ b/setup.py
@@ -20,17 +20,10 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         'msal>=0.4.1,<2.0.0',
-
-        "portalocker<3,>=1.0;platform_system!='Windows'",
-        "portalocker<3,>=1.6;platform_system=='Windows'",
+        'portalocker<3,>=1.4',
 
         ## We choose to NOT define a hard dependency on this.
         # "pygobject>=3,<4;platform_system=='Linux'",
-
-        # Packaging package uses YY.N versioning so we have no upperbound to pin.
-        # Neither do we need lowerbound because its `Version` API existed since its first release
-        # https://github.com/pypa/packaging/blame/14.0/packaging/version.py
-        'packaging',
     ],
     tests_require=['pytest'],
 )


### PR DESCRIPTION
`packaging` was only used as a dependency to check for the version of `portalocker` in use.

This drops that dependency and instead corrects the minimum version of `portalocker` to the one checked here.

It should be safe to depend on a version of `portalocker` that has been out for 3 years at this point, and is not quite as intrusive as #117 that would remove `portalocker` altogether (and in all honesty, that PR has been out there for a year, with no sign of merging).