### PR TITLE
Switch to MSAL 1.29+'s TokenCache.search()

### DIFF
--- a/msal_extensions/__init__.py
+++ b/msal_extensions/__init__.py
@@ -1,5 +1,5 @@
 """Provides auxiliary functionality to the `msal` package."""
-__version__ = "1.2.0b1"  # Note: During/after release, copy this number to Dockerfile
+__version__ = "1.2.0b2"  # Note: During/after release, copy this number to Dockerfile
 
 from .persistence import (
     FilePersistence,

--- a/msal_extensions/token_cache.py
+++ b/msal_extensions/token_cache.py
@@ -69,7 +69,7 @@ class PersistedTokenCache(msal.SerializableTokenCache):
             self._persistence.save(self.serialize())
             self._last_sync = time.time()
 
-    def _find(self, credential_type, **kwargs):  # pylint: disable=arguments-differ
+    def search(self, credential_type, **kwargs):  # pylint: disable=arguments-differ
         # Use optimistic locking rather than CrossPlatLock(self._lock_location)
         retry = 3
         for attempt in range(1, retry + 1):
@@ -83,6 +83,6 @@ class PersistedTokenCache(msal.SerializableTokenCache):
                 else:
                     raise  # End of retry. Re-raise the exception as-is.
             else:  # If reload encountered no error, the data is considered intact
-                return super(PersistedTokenCache, self)._find(credential_type, **kwargs)
+                return super(PersistedTokenCache, self).search(credential_type, **kwargs)
         return []  # Not really reachable here. Just to keep pylint happy.
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_data={'': ['LICENSE']},
     python_requires=">=3.7",
     install_requires=[
-        'msal>=1.27,<1.29',  # MSAL Python 1.29+ may not have TokenCache._find()
+        'msal>=1.29,<2',  # Use TokenCache.search() from MSAL Python 1.29+
         'portalocker<3,>=1.4',
 
         ## We choose to NOT define a hard dependency on this.

--- a/tests/test_agnostic_backend.py
+++ b/tests/test_agnostic_backend.py
@@ -32,7 +32,7 @@ def _test_token_cache_roundtrip(persistence):
     assert token2["token_source"] == "cache", "App2 should hit cache written by app1"
     assert token1['access_token'] == token2['access_token'], "Cache should hit"
 
-def test_token_cache_roundtrip_with_persistence_biulder(temp_location):
+def test_token_cache_roundtrip_with_persistence_builder(temp_location):
     _test_token_cache_roundtrip(build_encrypted_persistence(temp_location))
 
 def test_token_cache_roundtrip_with_file_persistence(temp_location):


### PR DESCRIPTION
This PR will only work when [this MSAL PR](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/693) is merged and shipped (possibly in version 1.29).

CC @jiasli 