### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,10 +19,15 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        include:
-          # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
-          - python-version: 3.7
+        exclude:  # https://github.com/actions/runner-images/issues/9770#issuecomment-2085623315
+          # Apple Silicon ARM64 does not support Python < v3.8
+          - python-version: "3.7"
+            os: macos-latest
+        include:  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
+          - # Run those legacy versions on macos13 runner which uses Intel CPUs
+            python-version: 3.7
             toxenv: "py37"
+            os: macos-13
           - python-version: 3.8
             toxenv: "py38"
           - python-version: 3.9

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,9 +39,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install Linux dependencies for Python 2
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '2.7' }}
       run: |
@@ -52,16 +53,10 @@ jobs:
       run: |
         sudo apt update
         sudo apt install python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-secret-1 gnome-keyring
-    - name: Install PyGObject on Linux
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pygobject
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pylint tox pytest
-        pip install .
+        pip install -r requirements.txt
     - name: Lint
       if: ${{ matrix.lint == 'true' }}
       run: |
@@ -100,9 +95,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
+        cache: 'pip'
     - name: Build a package for release
       run: |
         python -m pip install build --user

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+## Github actions/setup-python might need a requirements.txt to cache dependencies
+# https://github.com/actions/setup-python?tab=readme-ov-file#caching-packages-dependencies
+pygobject; sys_platform == 'linux'
+pylint
+tox
+pytest
+-e .


### PR DESCRIPTION
[Github's runner `macos-latest` has recently been updated](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/) and [it does not support Python 3.7](https://github.com/actions/runner-images/issues/9770). This PR adjusts our github action to work around that.

CC: @jiasli , this will unblock our upcoming work in this repo.