### PR TITLE
Allow portalocker version 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         'msal>=1.29,<2',  # Use TokenCache.search() from MSAL Python 1.29+
-        'portalocker<3,>=1.4',
+        'portalocker<4,>=1.4',
 
         ## We choose to NOT define a hard dependency on this.
         # "pygobject>=3,<4;platform_system=='Linux'",


### PR DESCRIPTION
See https://github.com/wolph/portalocker/releases/tag/v3.0.0; portalocker 3 drops support for end-of-life Python versions older than 3.9. The older portalocker versions allowed in the range still cover these Python interpreter versions.