### PR TITLE
Do not install tests in site-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ long_description = open('README.md').read()
 setup(
     name='msal-extensions',
     version=__version__,
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     long_description=long_description,
     long_description_content_type="text/markdown",
     package_data={'': ['LICENSE']},


### PR DESCRIPTION
Exclude `tests` from `find_packages()`.

Before this PR,

```
$ python3 -m venv _e
$ . _e/bin/activate
$ pip install msal-extensions
$ ls _e/lib/python3*/site-packages/tests/
cache_file_generator.py  __init__.py      __pycache__               test_cache_lock_file_perf.py  test_macos_backend.py  test_windows_backend.py
http_client.py           lock_acquire.py  test_agnostic_backend.py  test_crossplatlock.py         test_persistence.py
```

Obviously, we don’t want to install the tests as a top-level `tests` package. This is wrong and risks confusion and conflicts in a virtualenv, and it is even worse in a system-wide distribution package.

This appears to be a regression in 1.3.0, accidentally triggered by the addition of `tests/__init__.py` in 4b90cc82f8df44557c846939582b86ff1ffb41e0.

I can also reproduce the problem in a git checkout, working on `dev` (version numbers are 1.2.0 because https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/138 hasn’t been merged yet):

```
$ python3 -m build
[…]
creating '/home/ben/src/forks/microsoft-authentication-extensions-for-python/dist/.tmp-zepss87b/msal_extensions-1.2.0-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'msal_extensions/__init__.py'
adding 'msal_extensions/cache_lock.py'
adding 'msal_extensions/filelock.py'
adding 'msal_extensions/libsecret.py'
adding 'msal_extensions/osx.py'
adding 'msal_extensions/persistence.py'
adding 'msal_extensions/token_cache.py'
adding 'msal_extensions/windows.py'
adding 'tests/__init__.py'
adding 'tests/cache_file_generator.py'
adding 'tests/http_client.py'
adding 'tests/lock_acquire.py'
adding 'tests/test_agnostic_backend.py'
adding 'tests/test_cache_lock_file_perf.py'
adding 'tests/test_crossplatlock.py'
adding 'tests/test_macos_backend.py'
adding 'tests/test_persistence.py'
adding 'tests/test_windows_backend.py'
adding 'msal_extensions-1.2.0.dist-info/LICENSE'
adding 'msal_extensions-1.2.0.dist-info/METADATA'
adding 'msal_extensions-1.2.0.dist-info/WHEEL'
adding 'msal_extensions-1.2.0.dist-info/top_level.txt'
adding 'msal_extensions-1.2.0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Successfully built msal_extensions-1.2.0.tar.gz and msal_extensions-1.2.0-py3-none-any.whl
```

After this PR, the tests are no longer included in the wheel:

```
$ python3 -m build
[…]
creating '/home/ben/src/forks/microsoft-authentication-extensions-for-python/dist/.tmp-t_sgk6x7/msal_extensions-1.2.0-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'msal_extensions/__init__.py'
adding 'msal_extensions/cache_lock.py'
adding 'msal_extensions/filelock.py'
adding 'msal_extensions/libsecret.py'
adding 'msal_extensions/osx.py'
adding 'msal_extensions/persistence.py'
adding 'msal_extensions/token_cache.py'
adding 'msal_extensions/windows.py'
adding 'msal_extensions-1.2.0.dist-info/LICENSE'
adding 'msal_extensions-1.2.0.dist-info/METADATA'
adding 'msal_extensions-1.2.0.dist-info/WHEEL'
adding 'msal_extensions-1.2.0.dist-info/top_level.txt'
adding 'msal_extensions-1.2.0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Successfully built msal_extensions-1.2.0.tar.gz and msal_extensions-1.2.0-py3-none-any.whl
```