### PR TITLE
Remove tests module from distributed package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ long_description = open('README.md').read()
 setup(
     name='msal-extensions',
     version=__version__,
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests",)),
     long_description=long_description,
     long_description_content_type="text/markdown",
     package_data={'': ['LICENSE']},


### PR DESCRIPTION
Resolves https://github.com/AzureAD/microsoft-authentication-extensions-for-python/issues/140

This should remove `tests` directory from the published package. To confirm:

```
python3 -m build
unzip dist/msal_extensions-1.3.0-py3-none-any.whl -d extracted_wheel
ls -1 extracted_wheel 
```

output:

```
msal_extensions
msal_extensions-1.3.0.dist-info
```