### PR TITLE
Add missing import in token_cache_sample

### DIFF
--- a/sample/token_cache_sample.py
+++ b/sample/token_cache_sample.py
@@ -2,7 +2,7 @@ import sys
 import logging
 import json
 
-from msal_extensions import build_encrypted_persistence, FilePersistence
+from msal_extensions import build_encrypted_persistence, FilePersistence, PersistedTokenCache
 
 
 def build_persistence(location, fallback_to_plaintext=False):


### PR DESCRIPTION
It's just a tiny fix to add a missing import.

The previous code would fail with:
```
NameError: name 'PersistedTokenCache' is not defined
```